### PR TITLE
docs(settings): add two-node network setup and collapsible help

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,11 +36,29 @@ Open [http://localhost:5173](http://localhost:5173) in your browser.
 
 ### Connect to Local Node
 
-In a separate terminal, start a local clad-node:
+In the clad-studio directory, start a two-node local network for development:
 
 ```bash
-# In clad-studio directory
-./target/release/clad-node --dev --tmp
+# Terminal 1 - Start Alice (bootnode)
+./target/release/clad-node \
+  --chain local \
+  --alice \
+  --validator \
+  --tmp \
+  --port 30333 \
+  --rpc-port 9944 \
+  --node-key 0000000000000000000000000000000000000000000000000000000000000001
+
+# Terminal 2 - Start Bob (connects to Alice)
+./target/release/clad-node \
+  --chain local \
+  --bob \
+  --validator \
+  --tmp \
+  --port 30334 \
+  --rpc-port 9945 \
+  --node-key 0000000000000000000000000000000000000000000000000000000000000002 \
+  --bootnodes /ip4/127.0.0.1/tcp/30333/p2p/12D3KooWEyoppNCUx8Yx66oV9fJnriXwCcXwDDUA2kj6vnc6iDEp
 ```
 
 The dashboard will automatically connect to `ws://127.0.0.1:9944`.

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -383,24 +383,69 @@
 
 	<!-- Help Section -->
 	<div class="card">
-		<h2 class="text-lg font-medium text-[var(--color-navy)]">Connection Help</h2>
-		<div class="mt-4 space-y-3 text-sm text-[var(--color-slate)]">
-			<div>
+		<details class="group">
+			<summary class="cursor-pointer list-none">
+				<div class="flex items-center justify-between">
+					<h2 class="text-lg font-medium text-[var(--color-navy)]">Connection Help</h2>
+					<svg
+						class="h-5 w-5 text-[var(--color-navy)] transition-transform duration-200 group-open:rotate-180"
+						fill="none"
+						viewBox="0 0 24 24"
+						stroke="currentColor"
+					>
+						<path
+							stroke-linecap="round"
+							stroke-linejoin="round"
+							stroke-width="2"
+							d="M19 9l-7 7-7-7"
+						/>
+					</svg>
+				</div>
+				<div class="mt-4 text-sm text-[var(--color-slate)]">
+					<h3 class="font-medium text-[var(--color-navy)]">Secure Connections</h3>
+					<p class="mt-1">
+						For production nodes, use <code class="font-mono">wss://</code> for secure WebSocket connections.
+					</p>
+				</div>
+			</summary>
+			<div class="mt-4 text-sm text-[var(--color-slate)]">
 				<h3 class="font-medium text-[var(--color-navy)]">Local Development</h3>
-				<p class="mt-1">For local development, run your clad-node with:</p>
-				<code class="mt-2 block rounded bg-[var(--color-cream)] px-3 py-2 font-mono text-xs">
-					./target/release/clad-node --dev --tmp
-				</code>
+				<p class="mt-1">For local development, start a two-node network:</p>
+				<div class="mt-2 space-y-3">
+					<div>
+						<p class="mb-1 text-xs text-[var(--color-slate-light)]">
+							Terminal 1 - Start Alice (bootnode)
+						</p>
+						<pre
+							class="overflow-x-auto rounded bg-[var(--color-cream)] px-3 py-2 font-mono text-xs">./target/release/clad-node \
+  --chain local \
+  --alice \
+  --validator \
+  --tmp \
+  --port 30333 \
+  --rpc-port 9944 \
+  --node-key 0000000000000000000000000000000000000000000000000000000000000001</pre>
+					</div>
+					<div>
+						<p class="mb-1 text-xs text-[var(--color-slate-light)]">
+							Terminal 2 - Start Bob (connects to Alice)
+						</p>
+						<pre
+							class="overflow-x-auto rounded bg-[var(--color-cream)] px-3 py-2 font-mono text-xs">./target/release/clad-node \
+  --chain local \
+  --bob \
+  --validator \
+  --tmp \
+  --port 30334 \
+  --rpc-port 9945 \
+  --node-key 0000000000000000000000000000000000000000000000000000000000000002 \
+  --bootnodes /ip4/127.0.0.1/tcp/30333/p2p/12D3KooWEyoppNCUx8Yx66oV9fJnriXwCcXwDDUA2kj6vnc6iDEp</pre>
+					</div>
+				</div>
 				<p class="mt-2">
 					Default endpoint: <code class="font-mono">ws://127.0.0.1:9944</code>
 				</p>
 			</div>
-			<div>
-				<h3 class="font-medium text-[var(--color-navy)]">Secure Connections</h3>
-				<p class="mt-1">
-					For production nodes, use <code class="font-mono">wss://</code> for secure WebSocket connections.
-				</p>
-			</div>
-		</div>
+		</details>
 	</div>
 </div>


### PR DESCRIPTION
## Summary

- Update Connection Help section with Alice/Bob two-node network commands
- Make help section collapsible using native `<details>`/`<summary>` with chevron rotation animation
- Keep "Secure Connections" visible in summary, "Local Development" collapsible
- Update README with matching two-node network setup instructions

## Test plan

- [x] Open Settings page and verify Connection Help section displays correctly
- [x] Click chevron to expand/collapse - verify chevron rotates smoothly
- [x] Verify "Secure Connections" stays visible when collapsed
- [x] Verify "Local Development" with two-node commands shows when expanded
- [x] Check README has matching two-node network commands