### PR TITLE
feat(batch): add CSV upload and batch whitelist proposals

### DIFF
--- a/src/lib/api/call-data.ts
+++ b/src/lib/api/call-data.ts
@@ -7,10 +7,22 @@
  */
 
 import { get, isMockMode, post } from './client';
-import { mockCreateCallData, mockGetCallData } from './mock';
+import { mockCreateCallData, mockGetCallData, mockListCallData } from './mock';
 import type { ApiResult, CallData, CreateCallDataRequest } from './types';
 
 const BASE_PATH = '/api/v1/call-data';
+
+/**
+ * List all stored call data
+ *
+ * @returns Array of all call data, sorted by creation time (newest first)
+ */
+export async function listCallData(): Promise<ApiResult<CallData[]>> {
+	if (isMockMode()) {
+		return mockListCallData();
+	}
+	return get<CallData[]>(BASE_PATH);
+}
 
 /**
  * Store call data for a multi-sig operation

--- a/src/lib/api/index.ts
+++ b/src/lib/api/index.ts
@@ -42,7 +42,13 @@ export {
 } from './client';
 
 // CallData endpoints
-export { createCallData, getCallData, isValidCallHash, isValidEncodedCall } from './call-data';
+export {
+	listCallData,
+	createCallData,
+	getCallData,
+	isValidCallHash,
+	isValidEncodedCall
+} from './call-data';
 
 // Account endpoints
 export { listAccounts, getAccount, createAccount, updateAccount } from './accounts';

--- a/src/lib/api/mock.ts
+++ b/src/lib/api/mock.ts
@@ -160,6 +160,17 @@ export async function mockGetCallData(callHash: string): Promise<ApiResult<CallD
 }
 
 /**
+ * Mock list call data
+ */
+export async function mockListCallData(): Promise<ApiResult<CallData[]>> {
+	await delay();
+
+	const data = Array.from(mockCallData.values()).sort((a, b) => b.createdAt - a.createdAt);
+
+	return { success: true, data };
+}
+
+/**
  * Mock list accounts
  */
 export async function mockListAccounts(): Promise<ApiResult<AccountMetadata[]>> {

--- a/src/lib/components/BatchProgress.svelte
+++ b/src/lib/components/BatchProgress.svelte
@@ -1,0 +1,176 @@
+<script lang="ts">
+	import type { BatchResult } from '$lib/services';
+
+	interface Props {
+		/** Current progress (0 to total) */
+		current: number;
+		/** Total items to process */
+		total: number;
+		/** Current address being processed */
+		currentAddress?: string;
+		/** Final result (when complete) */
+		result?: BatchResult;
+		/** Called when user dismisses the result */
+		onDismiss?: () => void;
+	}
+
+	let { current, total, currentAddress, result, onDismiss }: Props = $props();
+
+	// Calculate percentage
+	let percentage = $derived(total > 0 ? Math.round((current / total) * 100) : 0);
+
+	// Format elapsed time
+	function formatElapsed(ms: number): string {
+		if (ms < 1000) return `${ms}ms`;
+		if (ms < 60000) return `${(ms / 1000).toFixed(1)}s`;
+		const minutes = Math.floor(ms / 60000);
+		const seconds = Math.floor((ms % 60000) / 1000);
+		return `${minutes}m ${seconds}s`;
+	}
+</script>
+
+{#if result}
+	<!-- Completed state -->
+	<div class="card">
+		<div class="flex items-start gap-4">
+			{#if result.failureCount === 0}
+				<!-- All successful -->
+				<div
+					class="flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-full bg-[var(--color-success-muted)]"
+				>
+					<svg
+						class="h-6 w-6 text-[var(--color-success)]"
+						fill="none"
+						viewBox="0 0 24 24"
+						stroke="currentColor"
+					>
+						<path
+							stroke-linecap="round"
+							stroke-linejoin="round"
+							stroke-width="2"
+							d="M5 13l4 4L19 7"
+						/>
+					</svg>
+				</div>
+				<div class="flex-1">
+					<h3 class="font-medium text-[var(--color-success)]">Proposals Created Successfully</h3>
+					<p class="mt-1 text-sm text-[var(--color-slate)]">
+						{result.successCount} whitelist proposal{result.successCount !== 1 ? 's' : ''} created in
+						{formatElapsed(result.elapsedMs)}
+					</p>
+				</div>
+			{:else if result.successCount === 0}
+				<!-- All failed -->
+				<div
+					class="flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-full bg-[var(--color-error-muted)]"
+				>
+					<svg
+						class="h-6 w-6 text-[var(--color-error)]"
+						fill="none"
+						viewBox="0 0 24 24"
+						stroke="currentColor"
+					>
+						<path
+							stroke-linecap="round"
+							stroke-linejoin="round"
+							stroke-width="2"
+							d="M6 18L18 6M6 6l12 12"
+						/>
+					</svg>
+				</div>
+				<div class="flex-1">
+					<h3 class="font-medium text-[var(--color-error)]">Failed to Create Proposals</h3>
+					<p class="mt-1 text-sm text-[var(--color-slate)]">
+						All {result.failureCount} proposal{result.failureCount !== 1 ? 's' : ''} failed. Check server
+						connection.
+					</p>
+				</div>
+			{:else}
+				<!-- Partial success -->
+				<div
+					class="flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-full bg-[var(--color-warning-muted)]"
+				>
+					<svg
+						class="h-6 w-6 text-[var(--color-warning)]"
+						fill="none"
+						viewBox="0 0 24 24"
+						stroke="currentColor"
+					>
+						<path
+							stroke-linecap="round"
+							stroke-linejoin="round"
+							stroke-width="2"
+							d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+						/>
+					</svg>
+				</div>
+				<div class="flex-1">
+					<h3 class="font-medium text-[var(--color-warning)]">Partially Completed</h3>
+					<p class="mt-1 text-sm text-[var(--color-slate)]">
+						{result.successCount} of {result.successCount + result.failureCount} proposals created.
+						{result.failureCount} failed.
+					</p>
+				</div>
+			{/if}
+			{#if onDismiss}
+				<button type="button" class="btn btn-secondary text-sm" onclick={onDismiss}> Done </button>
+			{/if}
+		</div>
+
+		<!-- Show failed addresses if any -->
+		{#if result.failureCount > 0}
+			<div class="mt-4 border-t border-[var(--color-border)] pt-4">
+				<h4 class="text-sm font-medium text-[var(--color-slate)]">Failed Addresses</h4>
+				<div class="mt-2 max-h-32 overflow-y-auto">
+					{#each result.results.filter((r) => !r.success) as failed (failed.address)}
+						<div class="flex items-center justify-between py-1 text-sm">
+							<code class="font-mono text-[var(--color-navy)]">
+								{failed.address.slice(0, 8)}...{failed.address.slice(-6)}
+							</code>
+							<span class="text-[var(--color-error)]">{failed.error}</span>
+						</div>
+					{/each}
+				</div>
+			</div>
+		{/if}
+	</div>
+{:else}
+	<!-- In progress state -->
+	<div class="card">
+		<div class="flex items-center gap-4">
+			<div class="flex-shrink-0">
+				<svg class="h-8 w-8 animate-spin text-[var(--color-teal)]" fill="none" viewBox="0 0 24 24">
+					<circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"
+					></circle>
+					<path
+						class="opacity-75"
+						fill="currentColor"
+						d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+					></path>
+				</svg>
+			</div>
+			<div class="flex-1">
+				<div class="flex items-center justify-between">
+					<h3 class="font-medium text-[var(--color-navy)]">Creating Proposals</h3>
+					<span class="text-sm text-[var(--color-slate)]">{current} of {total}</span>
+				</div>
+
+				<!-- Progress bar -->
+				<div class="mt-2 h-2 w-full rounded-full bg-[var(--color-cream)]">
+					<div
+						class="h-2 rounded-full bg-[var(--color-teal)] transition-all duration-300"
+						style="width: {percentage}%"
+					></div>
+				</div>
+
+				{#if currentAddress}
+					<p class="mt-2 text-xs text-[var(--color-slate-light)]">
+						Processing: <code class="font-mono"
+							>{currentAddress.slice(0, 8)}...{currentAddress.slice(-6)}</code
+						>
+					</p>
+				{/if}
+			</div>
+		</div>
+	</div>
+{/if}

--- a/src/lib/components/CsvPreviewTable.svelte
+++ b/src/lib/components/CsvPreviewTable.svelte
@@ -21,7 +21,7 @@
 	let showFilter = $state<'all' | 'valid' | 'invalid' | 'duplicate' | 'already_whitelisted'>('all');
 
 	// Get filtered entries
-	let filteredEntries = $derived(() => {
+	let filteredEntries = $derived.by(() => {
 		if (showFilter === 'all') {
 			return result.entries;
 		}
@@ -184,7 +184,7 @@
 					</tr>
 				</thead>
 				<tbody class="divide-y divide-[var(--color-border)]">
-					{#each filteredEntries() as entry (entry.lineNumber)}
+					{#each filteredEntries as entry (entry.lineNumber)}
 						{@const badge = getStatusBadge(entry.status)}
 						<tr class="hover:bg-[var(--color-cream)]/50">
 							<td class="px-4 py-3 text-sm text-[var(--color-slate-light)]">

--- a/src/lib/components/CsvPreviewTable.svelte
+++ b/src/lib/components/CsvPreviewTable.svelte
@@ -1,0 +1,280 @@
+<script lang="ts">
+	import { formatAddress } from '$lib/substrate/types';
+	import type { CsvParseResult, ParsedAddress } from '$lib/utils';
+
+	interface Props {
+		/** The parsed CSV result to display */
+		result: CsvParseResult;
+		/** The file name for display */
+		fileName: string;
+		/** Callback when user wants to clear the preview */
+		onClear: () => void;
+		/** Callback when user wants to proceed with valid addresses */
+		onProceed: (addresses: string[]) => void;
+		/** Whether proceeding is disabled (e.g., during submission) */
+		proceedDisabled?: boolean;
+	}
+
+	let { result, fileName, onClear, onProceed, proceedDisabled = false }: Props = $props();
+
+	// Filter options
+	let showFilter = $state<'all' | 'valid' | 'invalid' | 'duplicate' | 'already_whitelisted'>('all');
+
+	// Get filtered entries
+	let filteredEntries = $derived(() => {
+		if (showFilter === 'all') {
+			return result.entries;
+		}
+		return result.entries.filter((e) => e.status === showFilter);
+	});
+
+	// Get valid addresses for proceeding
+	function getValidAddresses(): string[] {
+		return result.entries.filter((e) => e.status === 'valid').map((e) => e.normalizedAddress!);
+	}
+
+	// Get badge class for status
+	function getStatusBadge(status: ParsedAddress['status']): {
+		class: string;
+		label: string;
+		icon: string;
+	} {
+		switch (status) {
+			case 'valid':
+				return {
+					class: 'badge-success',
+					label: 'Valid',
+					icon: 'M5 13l4 4L19 7'
+				};
+			case 'invalid':
+				return {
+					class: 'badge-error',
+					label: 'Invalid',
+					icon: 'M6 18L18 6M6 6l12 12'
+				};
+			case 'duplicate':
+				return {
+					class: 'badge-warning',
+					label: 'Duplicate',
+					icon: 'M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z'
+				};
+			case 'already_whitelisted':
+				return {
+					class: 'badge',
+					label: 'On Whitelist',
+					icon: 'M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z'
+				};
+		}
+	}
+</script>
+
+<div class="space-y-4">
+	<!-- Summary Card -->
+	<div class="card">
+		<div class="flex flex-wrap items-center justify-between gap-4">
+			<div class="flex items-center gap-3">
+				<div
+					class="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full bg-[var(--color-cream)]"
+				>
+					<svg
+						class="h-5 w-5 text-[var(--color-navy)]"
+						fill="none"
+						viewBox="0 0 24 24"
+						stroke="currentColor"
+					>
+						<path
+							stroke-linecap="round"
+							stroke-linejoin="round"
+							stroke-width="2"
+							d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
+						/>
+					</svg>
+				</div>
+				<div>
+					<h3 class="font-medium text-[var(--color-navy)]">{fileName}</h3>
+					<p class="text-sm text-[var(--color-slate-light)]">
+						{result.entries.length} address{result.entries.length !== 1 ? 'es' : ''} found
+					</p>
+				</div>
+			</div>
+			<button type="button" class="btn btn-secondary text-sm" onclick={onClear}>
+				<svg class="mr-2 h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+					<path
+						stroke-linecap="round"
+						stroke-linejoin="round"
+						stroke-width="2"
+						d="M6 18L18 6M6 6l12 12"
+					/>
+				</svg>
+				Clear
+			</button>
+		</div>
+
+		<!-- Stats -->
+		<div class="mt-4 grid grid-cols-2 gap-3 sm:grid-cols-4">
+			<button
+				type="button"
+				class="rounded-lg p-3 text-left transition-colors {showFilter === 'valid'
+					? 'bg-[var(--color-success-muted)] ring-2 ring-[var(--color-success)]'
+					: 'bg-[var(--color-cream)] hover:bg-[var(--color-cream)]/80'}"
+				onclick={() => (showFilter = showFilter === 'valid' ? 'all' : 'valid')}
+			>
+				<div class="text-2xl font-semibold text-[var(--color-success)]">{result.validCount}</div>
+				<div class="text-xs text-[var(--color-slate-light)]">Valid</div>
+			</button>
+			<button
+				type="button"
+				class="rounded-lg p-3 text-left transition-colors {showFilter === 'invalid'
+					? 'bg-[var(--color-error-muted)] ring-2 ring-[var(--color-error)]'
+					: 'bg-[var(--color-cream)] hover:bg-[var(--color-cream)]/80'}"
+				onclick={() => (showFilter = showFilter === 'invalid' ? 'all' : 'invalid')}
+			>
+				<div class="text-2xl font-semibold text-[var(--color-error)]">{result.invalidCount}</div>
+				<div class="text-xs text-[var(--color-slate-light)]">Invalid</div>
+			</button>
+			<button
+				type="button"
+				class="rounded-lg p-3 text-left transition-colors {showFilter === 'duplicate'
+					? 'bg-[var(--color-warning-muted)] ring-2 ring-[var(--color-warning)]'
+					: 'bg-[var(--color-cream)] hover:bg-[var(--color-cream)]/80'}"
+				onclick={() => (showFilter = showFilter === 'duplicate' ? 'all' : 'duplicate')}
+			>
+				<div class="text-2xl font-semibold text-[var(--color-warning)]">
+					{result.duplicateCount}
+				</div>
+				<div class="text-xs text-[var(--color-slate-light)]">Duplicates</div>
+			</button>
+			<button
+				type="button"
+				class="rounded-lg p-3 text-left transition-colors {showFilter === 'already_whitelisted'
+					? 'bg-[var(--color-cream)] ring-2 ring-[var(--color-slate)]'
+					: 'bg-[var(--color-cream)] hover:bg-[var(--color-cream)]/80'}"
+				onclick={() =>
+					(showFilter = showFilter === 'already_whitelisted' ? 'all' : 'already_whitelisted')}
+			>
+				<div class="text-2xl font-semibold text-[var(--color-slate)]">
+					{result.alreadyWhitelistedCount}
+				</div>
+				<div class="text-xs text-[var(--color-slate-light)]">Already Listed</div>
+			</button>
+		</div>
+	</div>
+
+	<!-- Address Table -->
+	<div class="card overflow-hidden p-0">
+		<div class="max-h-80 overflow-y-auto">
+			<table class="w-full">
+				<thead class="sticky top-0 bg-[var(--color-cream)]">
+					<tr class="border-b border-[var(--color-border)]">
+						<th
+							class="px-4 py-3 text-left text-xs font-medium tracking-wide text-[var(--color-slate)] uppercase"
+						>
+							Line
+						</th>
+						<th
+							class="px-4 py-3 text-left text-xs font-medium tracking-wide text-[var(--color-slate)] uppercase"
+						>
+							Address
+						</th>
+						<th
+							class="px-4 py-3 text-left text-xs font-medium tracking-wide text-[var(--color-slate)] uppercase"
+						>
+							Status
+						</th>
+					</tr>
+				</thead>
+				<tbody class="divide-y divide-[var(--color-border)]">
+					{#each filteredEntries() as entry (entry.lineNumber)}
+						{@const badge = getStatusBadge(entry.status)}
+						<tr class="hover:bg-[var(--color-cream)]/50">
+							<td class="px-4 py-3 text-sm text-[var(--color-slate-light)]">
+								{entry.lineNumber}
+							</td>
+							<td class="px-4 py-3">
+								<code class="font-mono text-sm text-[var(--color-navy)]">
+									{entry.normalizedAddress
+										? formatAddress(entry.normalizedAddress, 8)
+										: entry.originalAddress}
+								</code>
+								{#if entry.normalizedAddress && entry.originalAddress !== entry.normalizedAddress}
+									<div class="mt-0.5 text-xs text-[var(--color-slate-light)]">
+										Original: {entry.originalAddress.slice(0, 20)}...
+									</div>
+								{/if}
+							</td>
+							<td class="px-4 py-3">
+								<span class="badge {badge.class} inline-flex items-center gap-1">
+									<svg class="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+										<path
+											stroke-linecap="round"
+											stroke-linejoin="round"
+											stroke-width="2"
+											d={badge.icon}
+										/>
+									</svg>
+									{badge.label}
+								</span>
+								{#if entry.error}
+									<div class="mt-1 text-xs text-[var(--color-slate-light)]">{entry.error}</div>
+								{/if}
+							</td>
+						</tr>
+					{/each}
+				</tbody>
+			</table>
+		</div>
+	</div>
+
+	<!-- Action Buttons -->
+	{#if result.validCount > 0}
+		<div class="flex items-center justify-between">
+			<p class="text-sm text-[var(--color-slate)]">
+				{result.validCount} valid address{result.validCount !== 1 ? 'es' : ''} will be added to whitelist
+				proposals
+			</p>
+			<button
+				type="button"
+				class="btn btn-primary"
+				onclick={() => onProceed(getValidAddresses())}
+				disabled={proceedDisabled || result.validCount === 0}
+			>
+				{#if proceedDisabled}
+					<svg class="mr-2 h-4 w-4 animate-spin" viewBox="0 0 24 24" fill="none">
+						<circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"
+						></circle>
+						<path
+							class="opacity-75"
+							fill="currentColor"
+							d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+						></path>
+					</svg>
+					Creating Proposals...
+				{:else}
+					<svg class="mr-2 h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+						<path
+							stroke-linecap="round"
+							stroke-linejoin="round"
+							stroke-width="2"
+							d="M12 6v6m0 0v6m0-6h6m-6 0H6"
+						/>
+					</svg>
+					Create Proposals ({result.validCount})
+				{/if}
+			</button>
+		</div>
+	{:else}
+		<div class="rounded-md bg-[var(--color-warning-muted)] p-4 text-sm text-[#92400e]">
+			<div class="flex items-center gap-2">
+				<svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+					<path
+						stroke-linecap="round"
+						stroke-linejoin="round"
+						stroke-width="2"
+						d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+					/>
+				</svg>
+				No valid addresses to add. Please check your CSV file and try again.
+			</div>
+		</div>
+	{/if}
+</div>

--- a/src/lib/components/CsvUpload.svelte
+++ b/src/lib/components/CsvUpload.svelte
@@ -1,0 +1,171 @@
+<script lang="ts">
+	import { parseAddressCsv, formatFileSize, type CsvParseResult } from '$lib/utils';
+
+	interface Props {
+		/** Called when a file is parsed */
+		onParsed: (result: CsvParseResult, fileName: string) => void;
+		/** Set of addresses already on the whitelist (for duplicate detection) */
+		existingWhitelist?: Set<string>;
+		/** Whether the upload is disabled */
+		disabled?: boolean;
+	}
+
+	let { onParsed, existingWhitelist, disabled = false }: Props = $props();
+
+	let isDragging = $state(false);
+	let error = $state<string | null>(null);
+	let isProcessing = $state(false);
+
+	function handleDragOver(e: DragEvent) {
+		e.preventDefault();
+		if (!disabled) {
+			isDragging = true;
+		}
+	}
+
+	function handleDragLeave(e: DragEvent) {
+		e.preventDefault();
+		isDragging = false;
+	}
+
+	function handleDrop(e: DragEvent) {
+		e.preventDefault();
+		isDragging = false;
+
+		if (disabled) return;
+
+		const files = e.dataTransfer?.files;
+		if (files && files.length > 0) {
+			processFile(files[0]);
+		}
+	}
+
+	function handleFileSelect(e: Event) {
+		const input = e.target as HTMLInputElement;
+		const files = input.files;
+		if (files && files.length > 0) {
+			processFile(files[0]);
+		}
+		// Reset input so same file can be selected again
+		input.value = '';
+	}
+
+	async function processFile(file: File) {
+		error = null;
+
+		// Validate file type
+		if (!file.name.endsWith('.csv') && !file.name.endsWith('.txt')) {
+			error = 'Please upload a CSV or TXT file';
+			return;
+		}
+
+		// Validate file size (max 1MB)
+		const maxSize = 1024 * 1024;
+		if (file.size > maxSize) {
+			error = `File too large (${formatFileSize(file.size)}). Maximum size is 1 MB.`;
+			return;
+		}
+
+		isProcessing = true;
+
+		try {
+			const content = await file.text();
+			const result = parseAddressCsv(content, existingWhitelist);
+
+			if (result.entries.length === 0) {
+				error = 'No valid addresses found in file';
+				return;
+			}
+
+			onParsed(result, file.name);
+		} catch (e) {
+			console.error('Failed to parse CSV:', e);
+			error = e instanceof Error ? e.message : 'Failed to parse file';
+		} finally {
+			isProcessing = false;
+		}
+	}
+</script>
+
+<div
+	class="relative rounded-lg border-2 border-dashed transition-colors {isDragging
+		? 'border-[var(--color-teal)] bg-[var(--color-teal)]/5'
+		: 'border-[var(--color-border)] hover:border-[var(--color-slate-light)]'} {disabled
+		? 'cursor-not-allowed opacity-50'
+		: 'cursor-pointer'}"
+	role="button"
+	tabindex={disabled ? -1 : 0}
+	ondragover={handleDragOver}
+	ondragleave={handleDragLeave}
+	ondrop={handleDrop}
+	onkeydown={(e) => {
+		if (!disabled && (e.key === 'Enter' || e.key === ' ')) {
+			e.preventDefault();
+			document.getElementById('csv-file-input')?.click();
+		}
+	}}
+>
+	<input
+		type="file"
+		id="csv-file-input"
+		accept=".csv,.txt"
+		class="absolute inset-0 cursor-pointer opacity-0 {disabled ? 'pointer-events-none' : ''}"
+		onchange={handleFileSelect}
+		{disabled}
+	/>
+
+	<div class="flex flex-col items-center justify-center px-6 py-10">
+		{#if isProcessing}
+			<svg class="h-12 w-12 animate-spin text-[var(--color-teal)]" fill="none" viewBox="0 0 24 24">
+				<circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"
+				></circle>
+				<path
+					class="opacity-75"
+					fill="currentColor"
+					d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+				></path>
+			</svg>
+			<p class="mt-4 text-sm text-[var(--color-slate)]">Processing file...</p>
+		{:else}
+			<svg
+				class="h-12 w-12 text-[var(--color-slate-light)]"
+				fill="none"
+				viewBox="0 0 24 24"
+				stroke="currentColor"
+			>
+				<path
+					stroke-linecap="round"
+					stroke-linejoin="round"
+					stroke-width="1.5"
+					d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M15 13l-3-3m0 0l-3 3m3-3v12"
+				/>
+			</svg>
+			<p class="mt-4 text-sm font-medium text-[var(--color-navy)]">
+				{#if isDragging}
+					Drop file to upload
+				{:else}
+					Drag and drop a CSV file, or click to browse
+				{/if}
+			</p>
+			<p class="mt-1 text-xs text-[var(--color-slate-light)]">
+				CSV or TXT file with one address per line (max 1 MB)
+			</p>
+		{/if}
+	</div>
+</div>
+
+{#if error}
+	<div class="mt-3 rounded-md bg-[var(--color-error-muted)] p-3 text-sm text-[#991b1b]">
+		<div class="flex items-center gap-2">
+			<svg class="h-4 w-4 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+				<path
+					stroke-linecap="round"
+					stroke-linejoin="round"
+					stroke-width="2"
+					d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+				/>
+			</svg>
+			{error}
+		</div>
+	</div>
+{/if}

--- a/src/lib/components/Sidebar.svelte
+++ b/src/lib/components/Sidebar.svelte
@@ -13,6 +13,7 @@
 		{ href: '/', label: 'Overview', icon: 'home' },
 		{ href: '/balances', label: 'Balances', icon: 'wallet' },
 		{ href: '/whitelist', label: 'Whitelist', icon: 'users' },
+		{ href: '/proposals', label: 'Proposals', icon: 'clipboard' },
 		{ href: '/events', label: 'Events', icon: 'activity' },
 		{ href: '/multisig', label: 'Multi-sig', icon: 'shield' },
 		{ href: '/settings', label: 'Settings', icon: 'settings' }
@@ -26,6 +27,8 @@
 			'M3 10h18M7 15h1m4 0h1m-7 4h12a3 3 0 003-3V8a3 3 0 00-3-3H6a3 3 0 00-3 3v8a3 3 0 003 3z',
 		users:
 			'M12 4.354a4 4 0 110 5.292M15 21H3v-1a6 6 0 0112 0v1zm0 0h6v-1a6 6 0 00-9-5.197M13 7a4 4 0 11-8 0 4 4 0 018 0z',
+		clipboard:
+			'M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2',
 		activity: 'M22 12h-4l-3 9L9 3l-3 9H2',
 		shield:
 			'M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z',

--- a/src/lib/components/index.ts
+++ b/src/lib/components/index.ts
@@ -1,5 +1,8 @@
 export { default as AdminStatusWidget } from './AdminStatusWidget.svelte';
+export { default as BatchProgress } from './BatchProgress.svelte';
 export { default as CardSkeleton } from './CardSkeleton.svelte';
+export { default as CsvPreviewTable } from './CsvPreviewTable.svelte';
+export { default as CsvUpload } from './CsvUpload.svelte';
 export { default as Header } from './Header.svelte';
 export { default as Sidebar } from './Sidebar.svelte';
 export { default as Skeleton } from './Skeleton.svelte';

--- a/src/lib/services/batch-proposals.ts
+++ b/src/lib/services/batch-proposals.ts
@@ -1,0 +1,130 @@
+/**
+ * Batch proposal creation service.
+ *
+ * Handles encoding calls and submitting them to the CLAD Server
+ * with progress tracking for batch whitelist operations.
+ */
+
+import type { ApiPromise } from '@polkadot/api';
+import { createCallData } from '$lib/api';
+import { encodeBatchWhitelist } from '$lib/substrate';
+import type { CreateCallDataRequest } from '$lib/api/types';
+
+/**
+ * Progress callback type
+ */
+export type ProgressCallback = (current: number, total: number, address: string) => void;
+
+/**
+ * Result of creating a single proposal
+ */
+export interface ProposalResult {
+	address: string;
+	callHash: string;
+	success: boolean;
+	error?: string;
+}
+
+/**
+ * Result of batch proposal creation
+ */
+export interface BatchResult {
+	/** All results */
+	results: ProposalResult[];
+	/** Number of successful proposals */
+	successCount: number;
+	/** Number of failed proposals */
+	failureCount: number;
+	/** Total time in milliseconds */
+	elapsedMs: number;
+}
+
+/**
+ * Create batch whitelist proposals.
+ *
+ * Encodes each address as an addToWhitelist call and submits to the CLAD Server.
+ *
+ * @param api - Connected ApiPromise instance
+ * @param addresses - Array of SS58 addresses to whitelist
+ * @param createdBy - SS58 address of the proposer (for audit trail)
+ * @param onProgress - Optional progress callback
+ * @returns Batch result with individual proposal outcomes
+ */
+export async function createBatchWhitelistProposals(
+	api: ApiPromise,
+	addresses: string[],
+	createdBy: string,
+	onProgress?: ProgressCallback
+): Promise<BatchResult> {
+	const startTime = Date.now();
+	const results: ProposalResult[] = [];
+	let successCount = 0;
+	let failureCount = 0;
+
+	// Encode all calls first
+	const encodedCalls = encodeBatchWhitelist(api, addresses);
+
+	// Submit each to the server
+	for (let i = 0; i < encodedCalls.length; i++) {
+		const encoded = encodedCalls[i];
+
+		// Report progress
+		if (onProgress) {
+			onProgress(i + 1, encodedCalls.length, encoded.address);
+		}
+
+		// Create the request
+		const request: CreateCallDataRequest = {
+			callHash: encoded.callHash,
+			encodedCall: encoded.encodedCall,
+			palletName: encoded.palletName,
+			callName: encoded.callName,
+			createdBy,
+			description: `Add ${encoded.address} to whitelist`
+		};
+
+		// Submit to server
+		const result = await createCallData(request);
+
+		if (result.success) {
+			results.push({
+				address: encoded.address,
+				callHash: encoded.callHash,
+				success: true
+			});
+			successCount++;
+		} else {
+			results.push({
+				address: encoded.address,
+				callHash: encoded.callHash,
+				success: false,
+				error: result.error.message
+			});
+			failureCount++;
+		}
+	}
+
+	return {
+		results,
+		successCount,
+		failureCount,
+		elapsedMs: Date.now() - startTime
+	};
+}
+
+/**
+ * Create a single whitelist proposal.
+ *
+ * @param api - Connected ApiPromise instance
+ * @param address - SS58 address to whitelist
+ * @param createdBy - SS58 address of the proposer
+ * @returns Result of creating the proposal
+ */
+export async function createWhitelistProposal(
+	api: ApiPromise,
+	address: string,
+	createdBy: string
+): Promise<ProposalResult> {
+	const batch = await createBatchWhitelistProposals(api, [address], createdBy);
+	return batch.results[0];
+}

--- a/src/lib/services/index.ts
+++ b/src/lib/services/index.ts
@@ -1,0 +1,1 @@
+export * from './batch-proposals';

--- a/src/lib/substrate/call-encoder.ts
+++ b/src/lib/substrate/call-encoder.ts
@@ -32,6 +32,13 @@ export interface EncodedCall {
  * @returns Encoded call data with hash
  */
 export function encodeAddToWhitelist(api: ApiPromise, address: string): EncodedCall {
+	// Verify the pallet exists in the runtime
+	if (!api.tx.cladToken?.addToWhitelist) {
+		throw new Error(
+			'CladToken pallet not found in runtime. Ensure you are connected to the correct chain.'
+		);
+	}
+
 	// Create the call using the API
 	const call = api.tx.cladToken.addToWhitelist(address);
 

--- a/src/lib/substrate/call-encoder.ts
+++ b/src/lib/substrate/call-encoder.ts
@@ -1,0 +1,74 @@
+/**
+ * Utility for encoding Substrate calls and computing call hashes.
+ *
+ * Used to prepare addToWhitelist calls for batch proposal creation.
+ * The encoded call and its Blake2-256 hash are stored on the CLAD Server.
+ */
+
+import type { ApiPromise } from '@polkadot/api';
+import { blake2AsHex } from '@polkadot/util-crypto';
+
+/**
+ * Encoded call data with hash
+ */
+export interface EncodedCall {
+	/** The address being whitelisted */
+	address: string;
+	/** SCALE-encoded call bytes (0x prefixed) */
+	encodedCall: string;
+	/** Blake2-256 hash of the encoded call (0x + 64 hex) */
+	callHash: string;
+	/** Pallet name */
+	palletName: string;
+	/** Call name */
+	callName: string;
+}
+
+/**
+ * Encode a cladToken.addToWhitelist call.
+ *
+ * @param api - Connected ApiPromise instance
+ * @param address - SS58 address to whitelist
+ * @returns Encoded call data with hash
+ */
+export function encodeAddToWhitelist(api: ApiPromise, address: string): EncodedCall {
+	// Create the call using the API
+	const call = api.tx.cladToken.addToWhitelist(address);
+
+	// Get the encoded call data
+	const encodedCall = call.method.toHex();
+
+	// Compute the Blake2-256 hash of the encoded call
+	const callHash = blake2AsHex(call.method.toU8a(), 256);
+
+	return {
+		address,
+		encodedCall,
+		callHash,
+		palletName: 'CladToken',
+		callName: 'addToWhitelist'
+	};
+}
+
+/**
+ * Encode multiple addToWhitelist calls.
+ *
+ * @param api - Connected ApiPromise instance
+ * @param addresses - Array of SS58 addresses to whitelist
+ * @returns Array of encoded call data with hashes
+ */
+export function encodeBatchWhitelist(api: ApiPromise, addresses: string[]): EncodedCall[] {
+	return addresses.map((address) => encodeAddToWhitelist(api, address));
+}
+
+/**
+ * Verify a call hash matches the expected value for a given encoded call.
+ *
+ * @param encodedCall - SCALE-encoded call bytes (0x prefixed)
+ * @param expectedHash - Expected Blake2-256 hash (0x + 64 hex)
+ * @returns true if the hash matches
+ */
+export function verifyCallHash(encodedCall: string, expectedHash: string): boolean {
+	const computedHash = blake2AsHex(encodedCall, 256);
+	return computedHash.toLowerCase() === expectedHash.toLowerCase();
+}

--- a/src/lib/substrate/index.ts
+++ b/src/lib/substrate/index.ts
@@ -2,3 +2,4 @@
 export * from './client';
 export * from './types';
 export * from './call-decoder';
+export * from './call-encoder';

--- a/src/lib/utils/csv-parser.ts
+++ b/src/lib/utils/csv-parser.ts
@@ -1,0 +1,245 @@
+/**
+ * CSV parser for batch whitelist operations.
+ *
+ * Parses CSV files containing SS58 addresses, validates them,
+ * and detects duplicates within the file.
+ */
+
+import { decodeAddress, encodeAddress } from '@polkadot/util-crypto';
+
+/**
+ * Validation status for a parsed address
+ */
+export type AddressValidationStatus = 'valid' | 'invalid' | 'duplicate' | 'already_whitelisted';
+
+/**
+ * A parsed address entry from CSV
+ */
+export interface ParsedAddress {
+	/** Original address as it appeared in the CSV */
+	originalAddress: string;
+	/** Normalized SS58 address (if valid) */
+	normalizedAddress: string | null;
+	/** Line number in the CSV (1-indexed) */
+	lineNumber: number;
+	/** Validation status */
+	status: AddressValidationStatus;
+	/** Error message if invalid */
+	error?: string;
+}
+
+/**
+ * Result of parsing a CSV file
+ */
+export interface CsvParseResult {
+	/** All parsed entries */
+	entries: ParsedAddress[];
+	/** Count of valid addresses */
+	validCount: number;
+	/** Count of invalid addresses */
+	invalidCount: number;
+	/** Count of duplicates within the file */
+	duplicateCount: number;
+	/** Count of addresses already on the whitelist */
+	alreadyWhitelistedCount: number;
+}
+
+/**
+ * Validate and normalize an SS58 address.
+ *
+ * @param address - Raw address string to validate
+ * @returns Normalized address if valid, null if invalid
+ */
+export function validateSS58Address(address: string): {
+	valid: boolean;
+	normalized?: string;
+	error?: string;
+} {
+	const trimmed = address.trim();
+	if (!trimmed) {
+		return { valid: false, error: 'Empty address' };
+	}
+
+	try {
+		const decoded = decodeAddress(trimmed);
+		const normalized = encodeAddress(decoded);
+		return { valid: true, normalized };
+	} catch {
+		return { valid: false, error: 'Invalid SS58 address format' };
+	}
+}
+
+/**
+ * Parse a CSV file content containing addresses.
+ *
+ * Supports:
+ * - Single column CSV (address per line)
+ * - Multi-column CSV with 'address' header
+ * - Comments starting with # are ignored
+ * - Empty lines are ignored
+ *
+ * @param content - Raw CSV file content
+ * @param existingWhitelist - Optional set of already-whitelisted addresses for duplicate checking
+ * @returns Parsed result with validation status for each address
+ */
+export function parseAddressCsv(content: string, existingWhitelist?: Set<string>): CsvParseResult {
+	const lines = content.split(/\r?\n/);
+	const entries: ParsedAddress[] = [];
+	const seenAddresses = new Map<string, number>(); // normalized address -> first line number
+
+	let validCount = 0;
+	let invalidCount = 0;
+	let duplicateCount = 0;
+	let alreadyWhitelistedCount = 0;
+
+	// Detect if first line is a header
+	let startLine = 0;
+	let addressColumnIndex = 0;
+
+	if (lines.length > 0) {
+		const firstLine = lines[0].toLowerCase().trim();
+		if (firstLine.includes('address') || firstLine === 'account' || firstLine === 'wallet') {
+			// This is a header row
+			startLine = 1;
+			// Find the address column
+			const columns = parseCSVLine(lines[0]);
+			const idx = columns.findIndex(
+				(col) =>
+					col.toLowerCase() === 'address' ||
+					col.toLowerCase() === 'account' ||
+					col.toLowerCase() === 'wallet'
+			);
+			if (idx >= 0) {
+				addressColumnIndex = idx;
+			}
+		}
+	}
+
+	for (let i = startLine; i < lines.length; i++) {
+		const line = lines[i].trim();
+		const lineNumber = i + 1;
+
+		// Skip empty lines and comments
+		if (!line || line.startsWith('#')) {
+			continue;
+		}
+
+		// Parse CSV line (handles quoted values)
+		const columns = parseCSVLine(line);
+		const rawAddress = columns[addressColumnIndex]?.trim() || '';
+
+		if (!rawAddress) {
+			continue;
+		}
+
+		// Validate the address
+		const validation = validateSS58Address(rawAddress);
+
+		if (!validation.valid) {
+			entries.push({
+				originalAddress: rawAddress,
+				normalizedAddress: null,
+				lineNumber,
+				status: 'invalid',
+				error: validation.error
+			});
+			invalidCount++;
+			continue;
+		}
+
+		const normalized = validation.normalized!;
+
+		// Check for duplicates within the file
+		const existingLine = seenAddresses.get(normalized);
+		if (existingLine !== undefined) {
+			entries.push({
+				originalAddress: rawAddress,
+				normalizedAddress: normalized,
+				lineNumber,
+				status: 'duplicate',
+				error: `Duplicate of line ${existingLine}`
+			});
+			duplicateCount++;
+			continue;
+		}
+
+		// Check if already on whitelist
+		if (existingWhitelist?.has(normalized)) {
+			entries.push({
+				originalAddress: rawAddress,
+				normalizedAddress: normalized,
+				lineNumber,
+				status: 'already_whitelisted',
+				error: 'Already on whitelist'
+			});
+			alreadyWhitelistedCount++;
+			seenAddresses.set(normalized, lineNumber);
+			continue;
+		}
+
+		// Valid and unique
+		entries.push({
+			originalAddress: rawAddress,
+			normalizedAddress: normalized,
+			lineNumber,
+			status: 'valid'
+		});
+		seenAddresses.set(normalized, lineNumber);
+		validCount++;
+	}
+
+	return {
+		entries,
+		validCount,
+		invalidCount,
+		duplicateCount,
+		alreadyWhitelistedCount
+	};
+}
+
+/**
+ * Parse a single CSV line, handling quoted values.
+ */
+function parseCSVLine(line: string): string[] {
+	const result: string[] = [];
+	let current = '';
+	let inQuotes = false;
+
+	for (let i = 0; i < line.length; i++) {
+		const char = line[i];
+
+		if (char === '"') {
+			if (inQuotes && line[i + 1] === '"') {
+				// Escaped quote
+				current += '"';
+				i++;
+			} else {
+				inQuotes = !inQuotes;
+			}
+		} else if (char === ',' && !inQuotes) {
+			result.push(current.trim());
+			current = '';
+		} else {
+			current += char;
+		}
+	}
+
+	result.push(current.trim());
+	return result;
+}
+
+/**
+ * Get valid addresses from a parse result.
+ */
+export function getValidAddresses(result: CsvParseResult): string[] {
+	return result.entries.filter((e) => e.status === 'valid').map((e) => e.normalizedAddress!);
+}
+
+/**
+ * Format a file size for display.
+ */
+export function formatFileSize(bytes: number): string {
+	if (bytes < 1024) return `${bytes} B`;
+	if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+	return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -1,1 +1,2 @@
 export * from './format';
+export * from './csv-parser';

--- a/src/routes/proposals/+page.svelte
+++ b/src/routes/proposals/+page.svelte
@@ -91,13 +91,13 @@
 	}
 
 	// Get unique call names for filter
-	let callNames = $derived(() => {
+	let callNames = $derived.by(() => {
 		const names = new Set(proposals.map((p) => p.callName));
 		return ['all', ...Array.from(names).sort()];
 	});
 
 	// Filter proposals
-	let filteredProposals = $derived(() => {
+	let filteredProposals = $derived.by(() => {
 		if (filterCallName === 'all') {
 			return proposals;
 		}
@@ -269,7 +269,7 @@
 						bind:value={filterCallName}
 						class="mt-1 rounded-md border border-[var(--color-border)] px-3 py-1.5 text-sm focus:border-[var(--color-navy)] focus:ring-1 focus:ring-[var(--color-navy)] focus:outline-none"
 					>
-						{#each callNames() as name (name)}
+						{#each callNames as name (name)}
 							<option value={name}>
 								{name === 'all' ? 'All Types' : name}
 							</option>
@@ -278,7 +278,7 @@
 				</div>
 				<div class="flex-1"></div>
 				<div class="text-sm text-[var(--color-slate-light)]">
-					{filteredProposals().length} of {proposals.length} proposals
+					{filteredProposals.length} of {proposals.length} proposals
 				</div>
 			</div>
 		</div>
@@ -326,7 +326,7 @@
 			</div>
 		{:else}
 			<div class="space-y-4">
-				{#each filteredProposals() as proposal (proposal.callHash)}
+				{#each filteredProposals as proposal (proposal.callHash)}
 					<div class="card">
 						<div class="flex items-start justify-between gap-4">
 							<div class="flex items-start gap-3">

--- a/src/routes/proposals/+page.svelte
+++ b/src/routes/proposals/+page.svelte
@@ -1,0 +1,445 @@
+<script lang="ts">
+	import { onMount, onDestroy } from 'svelte';
+	import { goto } from '$app/navigation';
+	import { subscribeToConnectionState, getApiOrNull, decodeCall } from '$lib/substrate';
+	import { formatAddress } from '$lib/substrate/types';
+	import { CardSkeleton } from '$lib/components';
+	import { listCallData, subscribeToServerState, type ServerConnectionState } from '$lib/api';
+	import type { CallData } from '$lib/api/types';
+	import { formatDateTime } from '$lib/utils';
+
+	// Connection state
+	let serverConnectionState: ServerConnectionState = $state('disconnected');
+	let unsubscribeNodeState: (() => void) | null = null;
+	let unsubscribeServerState: (() => void) | null = null;
+
+	// Data state
+	let proposals = $state<CallData[]>([]);
+	let isLoading = $state(false);
+	let error = $state<string | null>(null);
+	let lastRefresh = $state<Date | null>(null);
+
+	// Filter state
+	let filterCallName = $state<string>('all');
+
+	// Polling interval (30 seconds)
+	let pollInterval: ReturnType<typeof setInterval> | null = null;
+	const POLL_INTERVAL_MS = 30000;
+
+	onMount(() => {
+		// Subscribe to node connection for call decoding
+		unsubscribeNodeState = subscribeToConnectionState(() => {
+			// Node state used for decoding calls - no direct action needed
+		});
+
+		unsubscribeServerState = subscribeToServerState((state) => {
+			serverConnectionState = state;
+			if (state === 'connected') {
+				fetchProposals();
+				startPolling();
+			} else {
+				stopPolling();
+			}
+		});
+	});
+
+	onDestroy(() => {
+		if (unsubscribeNodeState) unsubscribeNodeState();
+		if (unsubscribeServerState) unsubscribeServerState();
+		stopPolling();
+	});
+
+	function startPolling() {
+		stopPolling();
+		pollInterval = setInterval(() => {
+			if (serverConnectionState === 'connected') {
+				fetchProposals();
+			}
+		}, POLL_INTERVAL_MS);
+	}
+
+	function stopPolling() {
+		if (pollInterval) {
+			clearInterval(pollInterval);
+			pollInterval = null;
+		}
+	}
+
+	async function fetchProposals() {
+		isLoading = true;
+		error = null;
+
+		try {
+			const result = await listCallData();
+
+			if (result.success) {
+				proposals = result.data;
+				lastRefresh = new Date();
+			} else {
+				error = result.error.message;
+			}
+		} catch (e) {
+			console.error('Failed to fetch proposals:', e);
+			error = e instanceof Error ? e.message : 'Failed to fetch proposals';
+		} finally {
+			isLoading = false;
+		}
+	}
+
+	async function refresh() {
+		await fetchProposals();
+	}
+
+	// Get unique call names for filter
+	let callNames = $derived(() => {
+		const names = new Set(proposals.map((p) => p.callName));
+		return ['all', ...Array.from(names).sort()];
+	});
+
+	// Filter proposals
+	let filteredProposals = $derived(() => {
+		if (filterCallName === 'all') {
+			return proposals;
+		}
+		return proposals.filter((p) => p.callName === filterCallName);
+	});
+
+	// Format timestamp
+	function formatTimestamp(timestamp: number): string {
+		return formatDateTime(timestamp * 1000, 'medium', 'short');
+	}
+
+	// Get relative time
+	function getRelativeTime(timestamp: number): string {
+		const now = Date.now() / 1000;
+		const diff = now - timestamp;
+
+		if (diff < 60) return 'just now';
+		if (diff < 3600) return `${Math.floor(diff / 60)}m ago`;
+		if (diff < 86400) return `${Math.floor(diff / 3600)}h ago`;
+		return `${Math.floor(diff / 86400)}d ago`;
+	}
+
+	// Get badge class for call type
+	function getCallBadge(callName: string): string {
+		switch (callName) {
+			case 'addToWhitelist':
+				return 'badge-success';
+			case 'removeFromWhitelist':
+				return 'badge-warning';
+			case 'mint':
+				return 'badge-success';
+			case 'freeze':
+				return 'badge-error';
+			case 'unfreeze':
+				return 'badge-success';
+			default:
+				return 'badge';
+		}
+	}
+
+	// Decode call description from encoded call (if API connected)
+	function getCallDescription(proposal: CallData): string {
+		if (proposal.description) {
+			return proposal.description;
+		}
+
+		const api = getApiOrNull();
+		if (api && proposal.encodedCall) {
+			try {
+				const decoded = decodeCall(api, proposal.encodedCall);
+				if (decoded.success && decoded.description) {
+					return decoded.description;
+				}
+			} catch {
+				// Ignore decoding errors
+			}
+		}
+
+		return `${proposal.palletName}.${proposal.callName}`;
+	}
+
+	// Navigate to balances page
+	function navigateToBalance(address: string) {
+		goto(`/balances?address=${encodeURIComponent(address)}`);
+	}
+</script>
+
+<div class="space-y-6">
+	<!-- Page Header -->
+	<div class="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+		<div>
+			<h1 class="font-serif text-2xl text-[var(--color-navy)]">Proposals</h1>
+			<p class="mt-1 text-sm text-[var(--color-text-muted)]">
+				Call data stored on CLAD Server, waiting for multi-sig approval
+			</p>
+		</div>
+		<div class="flex gap-2">
+			<a href="/whitelist" class="btn btn-secondary">
+				<svg class="mr-2 h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+					<path
+						stroke-linecap="round"
+						stroke-linejoin="round"
+						stroke-width="2"
+						d="M12 6v6m0 0v6m0-6h6m-6 0H6"
+					/>
+				</svg>
+				New Batch
+			</a>
+			<button
+				type="button"
+				class="btn btn-secondary"
+				onclick={refresh}
+				disabled={isLoading || serverConnectionState !== 'connected'}
+			>
+				{#if isLoading}
+					<svg class="mr-2 h-4 w-4 animate-spin" viewBox="0 0 24 24" fill="none">
+						<circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"
+						></circle>
+						<path
+							class="opacity-75"
+							fill="currentColor"
+							d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+						></path>
+					</svg>
+				{:else}
+					<svg class="mr-2 h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+						<path
+							stroke-linecap="round"
+							stroke-linejoin="round"
+							stroke-width="2"
+							d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
+						/>
+					</svg>
+				{/if}
+				Refresh
+			</button>
+		</div>
+	</div>
+
+	<!-- Server connection warning -->
+	{#if serverConnectionState !== 'connected'}
+		<div class="rounded-md bg-[var(--color-warning-muted)] p-4 text-sm text-[#92400e]">
+			<div class="flex items-center gap-2">
+				<svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+					<path
+						stroke-linecap="round"
+						stroke-linejoin="round"
+						stroke-width="2"
+						d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+					/>
+				</svg>
+				{serverConnectionState === 'connecting'
+					? 'Connecting to CLAD Server...'
+					: 'Not connected to CLAD Server. Check Settings to configure the server URL.'}
+			</div>
+		</div>
+	{/if}
+
+	<!-- Error message -->
+	{#if error}
+		<div class="rounded-md bg-[var(--color-error-muted)] p-4 text-sm text-[#991b1b]">
+			<div class="flex items-center gap-2">
+				<svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+					<path
+						stroke-linecap="round"
+						stroke-linejoin="round"
+						stroke-width="2"
+						d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+					/>
+				</svg>
+				{error}
+			</div>
+		</div>
+	{/if}
+
+	<!-- Filter -->
+	{#if proposals.length > 0}
+		<div class="card">
+			<div class="flex flex-wrap items-center gap-4">
+				<div>
+					<label
+						for="filter-call"
+						class="block text-xs font-medium text-[var(--color-slate-light)]"
+					>
+						Filter by Type
+					</label>
+					<select
+						id="filter-call"
+						bind:value={filterCallName}
+						class="mt-1 rounded-md border border-[var(--color-border)] px-3 py-1.5 text-sm focus:border-[var(--color-navy)] focus:ring-1 focus:ring-[var(--color-navy)] focus:outline-none"
+					>
+						{#each callNames() as name (name)}
+							<option value={name}>
+								{name === 'all' ? 'All Types' : name}
+							</option>
+						{/each}
+					</select>
+				</div>
+				<div class="flex-1"></div>
+				<div class="text-sm text-[var(--color-slate-light)]">
+					{filteredProposals().length} of {proposals.length} proposals
+				</div>
+			</div>
+		</div>
+	{/if}
+
+	<!-- Loading state -->
+	{#if isLoading && proposals.length === 0}
+		<CardSkeleton count={3} />
+	{/if}
+
+	<!-- Proposals list -->
+	{#if !isLoading || proposals.length > 0}
+		{#if proposals.length === 0}
+			<div class="card">
+				<div class="flex flex-col items-center justify-center py-12">
+					<svg
+						class="h-12 w-12 text-[var(--color-slate-light)]"
+						fill="none"
+						viewBox="0 0 24 24"
+						stroke="currentColor"
+					>
+						<path
+							stroke-linecap="round"
+							stroke-linejoin="round"
+							stroke-width="2"
+							d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
+						/>
+					</svg>
+					<p class="mt-4 text-[var(--color-slate)]">No proposals found</p>
+					<p class="mt-1 text-sm text-[var(--color-slate-light)]">
+						Upload a CSV file from the Whitelist page to create batch proposals
+					</p>
+					<a href="/whitelist" class="btn btn-primary mt-4">
+						<svg class="mr-2 h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+							<path
+								stroke-linecap="round"
+								stroke-linejoin="round"
+								stroke-width="2"
+								d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M15 13l-3-3m0 0l-3 3m3-3v12"
+							/>
+						</svg>
+						Upload Addresses
+					</a>
+				</div>
+			</div>
+		{:else}
+			<div class="space-y-4">
+				{#each filteredProposals() as proposal (proposal.callHash)}
+					<div class="card">
+						<div class="flex items-start justify-between gap-4">
+							<div class="flex items-start gap-3">
+								<!-- Icon -->
+								<div
+									class="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full bg-[var(--color-cream)]"
+								>
+									<svg
+										class="h-5 w-5 text-[var(--color-navy)]"
+										fill="none"
+										viewBox="0 0 24 24"
+										stroke="currentColor"
+									>
+										<path
+											stroke-linecap="round"
+											stroke-linejoin="round"
+											stroke-width="2"
+											d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z"
+										/>
+									</svg>
+								</div>
+
+								<!-- Details -->
+								<div class="min-w-0 flex-1">
+									<div class="flex flex-wrap items-center gap-2">
+										<span class="badge {getCallBadge(proposal.callName)}">
+											{proposal.callName}
+										</span>
+										<span class="text-xs text-[var(--color-slate-light)]">
+											{proposal.palletName}
+										</span>
+									</div>
+									<p class="mt-1 text-sm text-[var(--color-navy)]">
+										{getCallDescription(proposal)}
+									</p>
+								</div>
+							</div>
+
+							<!-- Timestamp -->
+							<div class="text-right text-sm">
+								<div class="font-medium text-[var(--color-navy)]">
+									{getRelativeTime(proposal.createdAt)}
+								</div>
+								<div class="text-xs text-[var(--color-slate-light)]">
+									{formatTimestamp(proposal.createdAt)}
+								</div>
+							</div>
+						</div>
+
+						<!-- Details grid -->
+						<div class="mt-4 grid gap-4 sm:grid-cols-2">
+							<div>
+								<span
+									class="text-xs font-medium tracking-wide text-[var(--color-slate-light)] uppercase"
+								>
+									Created By
+								</span>
+								<button
+									type="button"
+									class="mt-1 block font-mono text-sm text-[var(--color-navy)] hover:text-[var(--color-teal)] hover:underline"
+									onclick={() => navigateToBalance(proposal.createdBy)}
+								>
+									{formatAddress(proposal.createdBy, 8)}
+								</button>
+							</div>
+							<div>
+								<span
+									class="text-xs font-medium tracking-wide text-[var(--color-slate-light)] uppercase"
+								>
+									Call Hash
+								</span>
+								<code
+									class="mt-1 block font-mono text-xs break-all text-[var(--color-slate)]"
+									title={proposal.callHash}
+								>
+									{proposal.callHash.slice(0, 18)}...{proposal.callHash.slice(-8)}
+								</code>
+							</div>
+						</div>
+
+						<!-- Read-only notice -->
+						<div
+							class="mt-4 flex items-center gap-2 rounded-md bg-[var(--color-cream)] p-3 text-sm text-[var(--color-slate)]"
+						>
+							<svg
+								class="h-4 w-4 flex-shrink-0"
+								fill="none"
+								viewBox="0 0 24 24"
+								stroke="currentColor"
+							>
+								<path
+									stroke-linecap="round"
+									stroke-linejoin="round"
+									stroke-width="2"
+									d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+								/>
+							</svg>
+							<span>
+								This proposal is stored on CLAD Server. Use CLAD Mobile to submit and approve
+								on-chain.
+							</span>
+						</div>
+					</div>
+				{/each}
+			</div>
+		{/if}
+	{/if}
+
+	<!-- Last refresh info -->
+	{#if lastRefresh && serverConnectionState === 'connected' && !isLoading}
+		<div class="text-sm text-[var(--color-slate-light)]">
+			Last refreshed: {lastRefresh.toLocaleTimeString()}
+			<span class="ml-2">(auto-refresh every 30s)</span>
+		</div>
+	{/if}
+</div>

--- a/src/routes/whitelist/+page.svelte
+++ b/src/routes/whitelist/+page.svelte
@@ -250,7 +250,8 @@
 		error = null;
 
 		try {
-			// Use a placeholder address for createdBy (in production, this would come from the connected wallet)
+			// TODO: In production, createdBy should come from user settings or authenticated session
+			// Currently using Alice's well-known dev address as a placeholder for development
 			const createdBy = '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY';
 
 			const result = await createBatchWhitelistProposals(

--- a/src/routes/whitelist/+page.svelte
+++ b/src/routes/whitelist/+page.svelte
@@ -1,14 +1,19 @@
 <script lang="ts">
 	import { onMount, onDestroy } from 'svelte';
+	import { SvelteSet } from 'svelte/reactivity';
 	import { subscribeToConnectionState, getApiOrNull, type ConnectionState } from '$lib/substrate';
 	import { formatAddress } from '$lib/substrate/types';
 	import { decodeAddress, encodeAddress } from '@polkadot/util-crypto';
+	import { CsvUpload, CsvPreviewTable, BatchProgress } from '$lib/components';
+	import { getServerConnectionState } from '$lib/api';
+	import { createBatchWhitelistProposals, type BatchResult } from '$lib/services';
+	import type { CsvParseResult } from '$lib/utils';
 
 	// Connection state
 	let connectionState: ConnectionState = $state('disconnected');
 	let unsubscribeState: (() => void) | null = null;
 
-	// Form state
+	// Form state (single address lookup)
 	let addressInput = $state('');
 	let isLoading = $state(false);
 	let error = $state<string | null>(null);
@@ -22,8 +27,25 @@
 		}>
 	>([]);
 
+	// Batch upload state
+	let csvResult = $state<CsvParseResult | null>(null);
+	let csvFileName = $state<string>('');
+	let isCreatingProposals = $state(false);
+	let batchProgress = $state<{ current: number; total: number; currentAddress: string }>({
+		current: 0,
+		total: 0,
+		currentAddress: ''
+	});
+	let batchResult = $state<BatchResult | null>(null);
+
+	// Existing whitelist (for duplicate detection)
+	let existingWhitelist = new SvelteSet<string>();
+
+	// View mode
+	let viewMode = $state<'lookup' | 'batch'>('lookup');
+
 	onMount(() => {
-		unsubscribeState = subscribeToConnectionState((state) => {
+		unsubscribeState = subscribeToConnectionState(async (state) => {
 			connectionState = state;
 		});
 	});
@@ -85,6 +107,7 @@
 		results = [];
 
 		const newResults: typeof results = [];
+		const whitelistedAddrs: string[] = [];
 
 		for (const rawAddr of rawAddresses) {
 			const validation = validateAddress(rawAddr);
@@ -108,6 +131,10 @@
 					address,
 					isWhitelisted
 				});
+
+				if (isWhitelisted) {
+					whitelistedAddrs.push(address);
+				}
 			} catch (e) {
 				console.error('Failed to lookup whitelist status:', e);
 				newResults.push({
@@ -119,6 +146,11 @@
 		}
 
 		results = newResults;
+		// Update existing whitelist with newly fetched addresses
+		existingWhitelist.clear();
+		for (const addr of whitelistedAddrs) {
+			existingWhitelist.add(addr);
+		}
 		isLoading = false;
 	}
 
@@ -178,6 +210,76 @@
 		}, 0);
 	}
 
+	/**
+	 * Handle CSV parse result
+	 */
+	function handleCsvParsed(result: CsvParseResult, fileName: string) {
+		csvResult = result;
+		csvFileName = fileName;
+		batchResult = null;
+	}
+
+	/**
+	 * Clear CSV preview
+	 */
+	function clearCsvPreview() {
+		csvResult = null;
+		csvFileName = '';
+		batchResult = null;
+	}
+
+	/**
+	 * Create proposals for valid addresses
+	 */
+	async function handleCreateProposals(addresses: string[]) {
+		const api = getApiOrNull();
+		if (!api) {
+			error = 'Not connected to node. Please wait for connection.';
+			return;
+		}
+
+		// Check server connection
+		const serverState = getServerConnectionState();
+		if (serverState.state !== 'connected') {
+			error = 'Not connected to CLAD Server. Please check Settings.';
+			return;
+		}
+
+		isCreatingProposals = true;
+		batchProgress = { current: 0, total: addresses.length, currentAddress: '' };
+		error = null;
+
+		try {
+			// Use a placeholder address for createdBy (in production, this would come from the connected wallet)
+			const createdBy = '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY';
+
+			const result = await createBatchWhitelistProposals(
+				api,
+				addresses,
+				createdBy,
+				(current, total, address) => {
+					batchProgress = { current, total, currentAddress: address };
+				}
+			);
+
+			batchResult = result;
+		} catch (e) {
+			console.error('Failed to create proposals:', e);
+			error = e instanceof Error ? e.message : 'Failed to create proposals';
+		} finally {
+			isCreatingProposals = false;
+		}
+	}
+
+	/**
+	 * Dismiss batch result and go back to upload
+	 */
+	function dismissBatchResult() {
+		batchResult = null;
+		csvResult = null;
+		csvFileName = '';
+	}
+
 	// Derived counts
 	let approvedCount = $derived(results.filter((r) => r.isWhitelisted && !r.error).length);
 	let notApprovedCount = $derived(results.filter((r) => !r.isWhitelisted && !r.error).length);
@@ -187,76 +289,361 @@
 <div class="space-y-6">
 	<!-- Page Header -->
 	<div>
-		<h1 class="font-serif text-2xl text-[var(--color-navy)]">KYC Whitelist Check</h1>
+		<h1 class="font-serif text-2xl text-[var(--color-navy)]">KYC Whitelist</h1>
 		<p class="mt-1 text-sm text-[var(--color-text-muted)]">
-			Verify if accounts are approved for CLAD token transfers
+			Verify whitelist status or batch upload addresses for proposals
 		</p>
 	</div>
 
-	<!-- Search Form -->
-	<div class="card">
-		<form onsubmit={handleSubmit} class="space-y-4">
-			<div>
-				<label for="addresses" class="block text-sm font-medium text-[var(--color-slate)]">
-					Account Address(es)
-				</label>
-				<p class="mt-0.5 text-xs text-[var(--color-slate-light)]">
-					Enter one or more addresses (comma, space, or newline separated)
-				</p>
-				<div class="mt-2">
-					<textarea
-						id="addresses"
-						bind:value={addressInput}
-						placeholder="Enter SS58 addresses...&#10;5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY&#10;5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty"
-						rows="4"
-						class="w-full rounded-md border border-[var(--color-border)] px-3 py-2 font-mono text-sm placeholder:text-[var(--color-slate-light)] focus:border-[var(--color-navy)] focus:ring-1 focus:ring-[var(--color-navy)] focus:outline-none"
-						disabled={connectionState !== 'connected' || isLoading}
-					></textarea>
-				</div>
-				<div class="mt-3 flex gap-2">
-					<button
-						type="submit"
-						class="btn btn-primary"
-						disabled={connectionState !== 'connected' || isLoading || !addressInput.trim()}
-					>
-						{#if isLoading}
-							<svg class="mr-2 h-4 w-4 animate-spin" viewBox="0 0 24 24" fill="none">
-								<circle
-									class="opacity-25"
-									cx="12"
-									cy="12"
-									r="10"
-									stroke="currentColor"
-									stroke-width="4"
-								></circle>
-								<path
-									class="opacity-75"
-									fill="currentColor"
-									d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-								></path>
-							</svg>
-							Checking...
-						{:else}
-							<svg class="mr-2 h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-								<path
-									stroke-linecap="round"
-									stroke-linejoin="round"
-									stroke-width="2"
-									d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
-								/>
-							</svg>
-							Check Status
+	<!-- View Mode Tabs -->
+	<div class="flex border-b border-[var(--color-border)]">
+		<button
+			type="button"
+			class="px-4 py-2 text-sm font-medium transition-colors {viewMode === 'lookup'
+				? 'border-b-2 border-[var(--color-navy)] text-[var(--color-navy)]'
+				: 'text-[var(--color-slate)] hover:text-[var(--color-navy)]'}"
+			onclick={() => (viewMode = 'lookup')}
+		>
+			<svg class="mr-2 inline-block h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+				<path
+					stroke-linecap="round"
+					stroke-linejoin="round"
+					stroke-width="2"
+					d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+				/>
+			</svg>
+			Status Lookup
+		</button>
+		<button
+			type="button"
+			class="px-4 py-2 text-sm font-medium transition-colors {viewMode === 'batch'
+				? 'border-b-2 border-[var(--color-navy)] text-[var(--color-navy)]'
+				: 'text-[var(--color-slate)] hover:text-[var(--color-navy)]'}"
+			onclick={() => (viewMode = 'batch')}
+		>
+			<svg class="mr-2 inline-block h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+				<path
+					stroke-linecap="round"
+					stroke-linejoin="round"
+					stroke-width="2"
+					d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M15 13l-3-3m0 0l-3 3m3-3v12"
+				/>
+			</svg>
+			Batch Upload
+		</button>
+	</div>
+
+	{#if viewMode === 'lookup'}
+		<!-- Single/Multi Address Lookup -->
+		<div class="card">
+			<form onsubmit={handleSubmit} class="space-y-4">
+				<div>
+					<label for="addresses" class="block text-sm font-medium text-[var(--color-slate)]">
+						Account Address(es)
+					</label>
+					<p class="mt-0.5 text-xs text-[var(--color-slate-light)]">
+						Enter one or more addresses (comma, space, or newline separated)
+					</p>
+					<div class="mt-2">
+						<textarea
+							id="addresses"
+							bind:value={addressInput}
+							placeholder="Enter SS58 addresses...&#10;5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY&#10;5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty"
+							rows="4"
+							class="w-full rounded-md border border-[var(--color-border)] px-3 py-2 font-mono text-sm placeholder:text-[var(--color-slate-light)] focus:border-[var(--color-navy)] focus:ring-1 focus:ring-[var(--color-navy)] focus:outline-none"
+							disabled={connectionState !== 'connected' || isLoading}
+						></textarea>
+					</div>
+					<div class="mt-3 flex gap-2">
+						<button
+							type="submit"
+							class="btn btn-primary"
+							disabled={connectionState !== 'connected' || isLoading || !addressInput.trim()}
+						>
+							{#if isLoading}
+								<svg class="mr-2 h-4 w-4 animate-spin" viewBox="0 0 24 24" fill="none">
+									<circle
+										class="opacity-25"
+										cx="12"
+										cy="12"
+										r="10"
+										stroke="currentColor"
+										stroke-width="4"
+									></circle>
+									<path
+										class="opacity-75"
+										fill="currentColor"
+										d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+									></path>
+								</svg>
+								Checking...
+							{:else}
+								<svg class="mr-2 h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+									<path
+										stroke-linecap="round"
+										stroke-linejoin="round"
+										stroke-width="2"
+										d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
+									/>
+								</svg>
+								Check Status
+							{/if}
+						</button>
+						{#if results.length > 0 || error}
+							<button type="button" class="btn btn-secondary" onclick={clearForm}>Clear</button>
 						{/if}
+					</div>
+				</div>
+			</form>
+
+			{#if connectionState !== 'connected'}
+				<div class="mt-4 rounded-md bg-[var(--color-warning-muted)] p-3 text-sm text-[#92400e]">
+					<div class="flex items-center gap-2">
+						<svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+							<path
+								stroke-linecap="round"
+								stroke-linejoin="round"
+								stroke-width="2"
+								d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+							/>
+						</svg>
+						{connectionState === 'connecting' ? 'Connecting to node...' : 'Not connected to node'}
+					</div>
+				</div>
+			{/if}
+
+			{#if error}
+				<div class="mt-4 rounded-md bg-[var(--color-error-muted)] p-3 text-sm text-[#991b1b]">
+					<div class="flex items-center gap-2">
+						<svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+							<path
+								stroke-linecap="round"
+								stroke-linejoin="round"
+								stroke-width="2"
+								d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+							/>
+						</svg>
+						{error}
+					</div>
+				</div>
+			{/if}
+		</div>
+
+		<!-- Lookup Results -->
+		{#if results.length > 0}
+			<!-- Summary Bar -->
+			<div class="card">
+				<div class="flex items-center justify-between">
+					<div class="flex items-center gap-6">
+						<div class="text-sm">
+							<span class="text-[var(--color-slate-light)]">Total:</span>
+							<span class="ml-1 font-semibold text-[var(--color-navy)]">{results.length}</span>
+						</div>
+						<div class="text-sm">
+							<span class="text-[var(--color-slate-light)]">Approved:</span>
+							<span class="ml-1 font-semibold text-[var(--color-success)]">{approvedCount}</span>
+						</div>
+						<div class="text-sm">
+							<span class="text-[var(--color-slate-light)]">Not Approved:</span>
+							<span class="ml-1 font-semibold text-[var(--color-error)]">{notApprovedCount}</span>
+						</div>
+						{#if errorCount > 0}
+							<div class="text-sm">
+								<span class="text-[var(--color-slate-light)]">Errors:</span>
+								<span class="ml-1 font-semibold text-[var(--color-warning)]">{errorCount}</span>
+							</div>
+						{/if}
+					</div>
+					<button type="button" class="btn btn-secondary text-sm" onclick={exportCSV}>
+						<svg class="mr-2 h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+							<path
+								stroke-linecap="round"
+								stroke-linejoin="round"
+								stroke-width="2"
+								d="M12 10v6m0 0l-3-3m3 3l3-3m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
+							/>
+						</svg>
+						Export CSV
 					</button>
-					{#if results.length > 0 || error}
-						<button type="button" class="btn btn-secondary" onclick={clearForm}>Clear</button>
-					{/if}
 				</div>
 			</div>
-		</form>
 
+			<!-- Results List -->
+			{#if results.length === 1}
+				<!-- Single result - large display -->
+				{@const result = results[0]}
+				<div class="card">
+					{#if result.error}
+						<!-- Error state -->
+						<div class="flex flex-col items-center py-8">
+							<div
+								class="flex h-20 w-20 items-center justify-center rounded-full bg-[var(--color-warning-muted)]"
+							>
+								<svg
+									class="h-10 w-10 text-[var(--color-warning)]"
+									fill="none"
+									viewBox="0 0 24 24"
+									stroke="currentColor"
+								>
+									<path
+										stroke-linecap="round"
+										stroke-linejoin="round"
+										stroke-width="2"
+										d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+									/>
+								</svg>
+							</div>
+							<h2 class="mt-4 text-xl font-semibold text-[var(--color-warning)]">Lookup Error</h2>
+							<p class="mt-2 text-sm text-[var(--color-slate)]">{result.error}</p>
+							<code
+								class="mt-4 rounded bg-[var(--color-cream)] px-3 py-2 font-mono text-sm break-all text-[var(--color-navy)]"
+							>
+								{result.address}
+							</code>
+						</div>
+					{:else if result.isWhitelisted}
+						<!-- Approved state -->
+						<div class="flex flex-col items-center py-8">
+							<div
+								class="flex h-20 w-20 items-center justify-center rounded-full bg-[var(--color-success-muted)]"
+							>
+								<svg
+									class="h-10 w-10 text-[var(--color-success)]"
+									fill="none"
+									viewBox="0 0 24 24"
+									stroke="currentColor"
+								>
+									<path
+										stroke-linecap="round"
+										stroke-linejoin="round"
+										stroke-width="2"
+										d="M5 13l4 4L19 7"
+									/>
+								</svg>
+							</div>
+							<h2 class="mt-4 text-xl font-semibold text-[var(--color-success)]">KYC Approved</h2>
+							<p class="mt-2 text-sm text-[var(--color-slate)]">
+								This account is approved for CLAD token transfers
+							</p>
+							<code
+								class="mt-4 rounded bg-[var(--color-cream)] px-3 py-2 font-mono text-sm break-all text-[var(--color-navy)]"
+							>
+								{result.address}
+							</code>
+						</div>
+					{:else}
+						<!-- Not approved state -->
+						<div class="flex flex-col items-center py-8">
+							<div
+								class="flex h-20 w-20 items-center justify-center rounded-full bg-[var(--color-error-muted)]"
+							>
+								<svg
+									class="h-10 w-10 text-[var(--color-error)]"
+									fill="none"
+									viewBox="0 0 24 24"
+									stroke="currentColor"
+								>
+									<path
+										stroke-linecap="round"
+										stroke-linejoin="round"
+										stroke-width="2"
+										d="M6 18L18 6M6 6l12 12"
+									/>
+								</svg>
+							</div>
+							<h2 class="mt-4 text-xl font-semibold text-[var(--color-error)]">Not Approved</h2>
+							<p class="mt-2 text-sm text-[var(--color-slate)]">
+								This account has not completed KYC verification
+							</p>
+							<code
+								class="mt-4 rounded bg-[var(--color-cream)] px-3 py-2 font-mono text-sm break-all text-[var(--color-navy)]"
+							>
+								{result.address}
+							</code>
+						</div>
+					{/if}
+				</div>
+			{:else}
+				<!-- Multiple results - table display -->
+				<div class="card overflow-x-auto p-0">
+					<table class="w-full min-w-[400px]">
+						<thead>
+							<tr class="border-b border-[var(--color-border)] bg-[var(--color-cream)]">
+								<th
+									class="px-4 py-3 text-left text-xs font-medium tracking-wide text-[var(--color-slate)] uppercase"
+								>
+									Address
+								</th>
+								<th
+									class="px-4 py-3 text-left text-xs font-medium tracking-wide text-[var(--color-slate)] uppercase"
+								>
+									Status
+								</th>
+							</tr>
+						</thead>
+						<tbody class="divide-y divide-[var(--color-border)]">
+							{#each results as result (result.address)}
+								<tr class="hover:bg-[var(--color-cream)]/50">
+									<td class="px-4 py-3">
+										<div class="flex flex-col">
+											<code class="font-mono text-sm text-[var(--color-navy)]">
+												{formatAddress(result.address, 8)}
+											</code>
+											<span class="mt-0.5 font-mono text-xs text-[var(--color-slate-light)]">
+												{result.address}
+											</span>
+										</div>
+									</td>
+									<td class="px-4 py-3">
+										{#if result.error}
+											<span class="badge badge-warning">Error: {result.error}</span>
+										{:else if result.isWhitelisted}
+											<span class="badge badge-success">
+												<svg
+													class="mr-1 h-3 w-3"
+													fill="none"
+													viewBox="0 0 24 24"
+													stroke="currentColor"
+												>
+													<path
+														stroke-linecap="round"
+														stroke-linejoin="round"
+														stroke-width="2"
+														d="M5 13l4 4L19 7"
+													/>
+												</svg>
+												Approved
+											</span>
+										{:else}
+											<span class="badge badge-error">
+												<svg
+													class="mr-1 h-3 w-3"
+													fill="none"
+													viewBox="0 0 24 24"
+													stroke="currentColor"
+												>
+													<path
+														stroke-linecap="round"
+														stroke-linejoin="round"
+														stroke-width="2"
+														d="M6 18L18 6M6 6l12 12"
+													/>
+												</svg>
+												Not Approved
+											</span>
+										{/if}
+									</td>
+								</tr>
+							{/each}
+						</tbody>
+					</table>
+				</div>
+			{/if}
+		{/if}
+	{:else}
+		<!-- Batch Upload View -->
 		{#if connectionState !== 'connected'}
-			<div class="mt-4 rounded-md bg-[var(--color-warning-muted)] p-3 text-sm text-[#92400e]">
+			<div class="rounded-md bg-[var(--color-warning-muted)] p-4 text-sm text-[#92400e]">
 				<div class="flex items-center gap-2">
 					<svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
 						<path
@@ -269,10 +656,98 @@
 					{connectionState === 'connecting' ? 'Connecting to node...' : 'Not connected to node'}
 				</div>
 			</div>
+		{:else if isCreatingProposals}
+			<!-- Progress display -->
+			<BatchProgress
+				current={batchProgress.current}
+				total={batchProgress.total}
+				currentAddress={batchProgress.currentAddress}
+			/>
+		{:else if batchResult}
+			<!-- Result display -->
+			<BatchProgress
+				current={batchProgress.total}
+				total={batchProgress.total}
+				result={batchResult}
+				onDismiss={dismissBatchResult}
+			/>
+
+			{#if batchResult.successCount > 0}
+				<div class="flex justify-center">
+					<a href="/proposals" class="btn btn-primary">
+						<svg class="mr-2 h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+							<path
+								stroke-linecap="round"
+								stroke-linejoin="round"
+								stroke-width="2"
+								d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"
+							/>
+						</svg>
+						View Proposals
+					</a>
+				</div>
+			{/if}
+		{:else if csvResult}
+			<!-- CSV Preview -->
+			<CsvPreviewTable
+				result={csvResult}
+				fileName={csvFileName}
+				onClear={clearCsvPreview}
+				onProceed={handleCreateProposals}
+			/>
+		{:else}
+			<!-- Upload area -->
+			<div class="card">
+				<h3 class="mb-4 font-medium text-[var(--color-navy)]">Upload Addresses</h3>
+				<CsvUpload onParsed={handleCsvParsed} {existingWhitelist} />
+
+				<div class="mt-4 rounded-md bg-[var(--color-cream)] p-4">
+					<h4 class="text-sm font-medium text-[var(--color-navy)]">CSV Format</h4>
+					<p class="mt-1 text-xs text-[var(--color-slate-light)]">
+						Upload a CSV file with one SS58 address per line. Optional header row is supported.
+					</p>
+					<pre class="mt-2 rounded bg-white p-3 font-mono text-xs text-[var(--color-slate)]">address
+5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
+5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty
+5FLSigC9HGRKVhB9FiEo4Y3koPsNmBmLJbpXg2mp1hXcS59Y</pre>
+				</div>
+			</div>
+
+			<!-- Info box -->
+			<div class="card">
+				<div class="flex items-start gap-3">
+					<svg
+						class="h-5 w-5 flex-shrink-0 text-[var(--color-teal)]"
+						fill="none"
+						viewBox="0 0 24 24"
+						stroke="currentColor"
+					>
+						<path
+							stroke-linecap="round"
+							stroke-linejoin="round"
+							stroke-width="2"
+							d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+						/>
+					</svg>
+					<div>
+						<h4 class="font-medium text-[var(--color-navy)]">How Batch Upload Works</h4>
+						<ol class="mt-2 list-inside list-decimal space-y-1 text-sm text-[var(--color-slate)]">
+							<li>Upload a CSV file with addresses to whitelist</li>
+							<li>Review and validate addresses (duplicates and errors are flagged)</li>
+							<li>Click "Create Proposals" to submit to CLAD Server</li>
+							<li>Proposals appear in the Proposals page for mobile approval</li>
+							<li>Signatories use CLAD Mobile to approve and submit to the chain</li>
+						</ol>
+						<p class="mt-3 text-xs text-[var(--color-slate-light)]">
+							Note: Dashboard cannot sign transactions. All approvals must be done via CLAD Mobile.
+						</p>
+					</div>
+				</div>
+			</div>
 		{/if}
 
 		{#if error}
-			<div class="mt-4 rounded-md bg-[var(--color-error-muted)] p-3 text-sm text-[#991b1b]">
+			<div class="rounded-md bg-[var(--color-error-muted)] p-4 text-sm text-[#991b1b]">
 				<div class="flex items-center gap-2">
 					<svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
 						<path
@@ -284,218 +759,6 @@
 					</svg>
 					{error}
 				</div>
-			</div>
-		{/if}
-	</div>
-
-	<!-- Results -->
-	{#if results.length > 0}
-		<!-- Summary Bar -->
-		<div class="card">
-			<div class="flex items-center justify-between">
-				<div class="flex items-center gap-6">
-					<div class="text-sm">
-						<span class="text-[var(--color-slate-light)]">Total:</span>
-						<span class="ml-1 font-semibold text-[var(--color-navy)]">{results.length}</span>
-					</div>
-					<div class="text-sm">
-						<span class="text-[var(--color-slate-light)]">Approved:</span>
-						<span class="ml-1 font-semibold text-[var(--color-success)]">{approvedCount}</span>
-					</div>
-					<div class="text-sm">
-						<span class="text-[var(--color-slate-light)]">Not Approved:</span>
-						<span class="ml-1 font-semibold text-[var(--color-error)]">{notApprovedCount}</span>
-					</div>
-					{#if errorCount > 0}
-						<div class="text-sm">
-							<span class="text-[var(--color-slate-light)]">Errors:</span>
-							<span class="ml-1 font-semibold text-[var(--color-warning)]">{errorCount}</span>
-						</div>
-					{/if}
-				</div>
-				<button type="button" class="btn btn-secondary text-sm" onclick={exportCSV}>
-					<svg class="mr-2 h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-						<path
-							stroke-linecap="round"
-							stroke-linejoin="round"
-							stroke-width="2"
-							d="M12 10v6m0 0l-3-3m3 3l3-3m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
-						/>
-					</svg>
-					Export CSV
-				</button>
-			</div>
-		</div>
-
-		<!-- Results List -->
-		{#if results.length === 1}
-			<!-- Single result - large display -->
-			{@const result = results[0]}
-			<div class="card">
-				{#if result.error}
-					<!-- Error state -->
-					<div class="flex flex-col items-center py-8">
-						<div
-							class="flex h-20 w-20 items-center justify-center rounded-full bg-[var(--color-warning-muted)]"
-						>
-							<svg
-								class="h-10 w-10 text-[var(--color-warning)]"
-								fill="none"
-								viewBox="0 0 24 24"
-								stroke="currentColor"
-							>
-								<path
-									stroke-linecap="round"
-									stroke-linejoin="round"
-									stroke-width="2"
-									d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
-								/>
-							</svg>
-						</div>
-						<h2 class="mt-4 text-xl font-semibold text-[var(--color-warning)]">Lookup Error</h2>
-						<p class="mt-2 text-sm text-[var(--color-slate)]">{result.error}</p>
-						<code
-							class="mt-4 rounded bg-[var(--color-cream)] px-3 py-2 font-mono text-sm break-all text-[var(--color-navy)]"
-						>
-							{result.address}
-						</code>
-					</div>
-				{:else if result.isWhitelisted}
-					<!-- Approved state -->
-					<div class="flex flex-col items-center py-8">
-						<div
-							class="flex h-20 w-20 items-center justify-center rounded-full bg-[var(--color-success-muted)]"
-						>
-							<svg
-								class="h-10 w-10 text-[var(--color-success)]"
-								fill="none"
-								viewBox="0 0 24 24"
-								stroke="currentColor"
-							>
-								<path
-									stroke-linecap="round"
-									stroke-linejoin="round"
-									stroke-width="2"
-									d="M5 13l4 4L19 7"
-								/>
-							</svg>
-						</div>
-						<h2 class="mt-4 text-xl font-semibold text-[var(--color-success)]">KYC Approved</h2>
-						<p class="mt-2 text-sm text-[var(--color-slate)]">
-							This account is approved for CLAD token transfers
-						</p>
-						<code
-							class="mt-4 rounded bg-[var(--color-cream)] px-3 py-2 font-mono text-sm break-all text-[var(--color-navy)]"
-						>
-							{result.address}
-						</code>
-					</div>
-				{:else}
-					<!-- Not approved state -->
-					<div class="flex flex-col items-center py-8">
-						<div
-							class="flex h-20 w-20 items-center justify-center rounded-full bg-[var(--color-error-muted)]"
-						>
-							<svg
-								class="h-10 w-10 text-[var(--color-error)]"
-								fill="none"
-								viewBox="0 0 24 24"
-								stroke="currentColor"
-							>
-								<path
-									stroke-linecap="round"
-									stroke-linejoin="round"
-									stroke-width="2"
-									d="M6 18L18 6M6 6l12 12"
-								/>
-							</svg>
-						</div>
-						<h2 class="mt-4 text-xl font-semibold text-[var(--color-error)]">Not Approved</h2>
-						<p class="mt-2 text-sm text-[var(--color-slate)]">
-							This account has not completed KYC verification
-						</p>
-						<code
-							class="mt-4 rounded bg-[var(--color-cream)] px-3 py-2 font-mono text-sm break-all text-[var(--color-navy)]"
-						>
-							{result.address}
-						</code>
-					</div>
-				{/if}
-			</div>
-		{:else}
-			<!-- Multiple results - table display -->
-			<div class="card overflow-x-auto p-0">
-				<table class="w-full min-w-[400px]">
-					<thead>
-						<tr class="border-b border-[var(--color-border)] bg-[var(--color-cream)]">
-							<th
-								class="px-4 py-3 text-left text-xs font-medium tracking-wide text-[var(--color-slate)] uppercase"
-							>
-								Address
-							</th>
-							<th
-								class="px-4 py-3 text-left text-xs font-medium tracking-wide text-[var(--color-slate)] uppercase"
-							>
-								Status
-							</th>
-						</tr>
-					</thead>
-					<tbody class="divide-y divide-[var(--color-border)]">
-						{#each results as result (result.address)}
-							<tr class="hover:bg-[var(--color-cream)]/50">
-								<td class="px-4 py-3">
-									<div class="flex flex-col">
-										<code class="font-mono text-sm text-[var(--color-navy)]">
-											{formatAddress(result.address, 8)}
-										</code>
-										<span class="mt-0.5 font-mono text-xs text-[var(--color-slate-light)]">
-											{result.address}
-										</span>
-									</div>
-								</td>
-								<td class="px-4 py-3">
-									{#if result.error}
-										<span class="badge badge-warning">Error: {result.error}</span>
-									{:else if result.isWhitelisted}
-										<span class="badge badge-success">
-											<svg
-												class="mr-1 h-3 w-3"
-												fill="none"
-												viewBox="0 0 24 24"
-												stroke="currentColor"
-											>
-												<path
-													stroke-linecap="round"
-													stroke-linejoin="round"
-													stroke-width="2"
-													d="M5 13l4 4L19 7"
-												/>
-											</svg>
-											Approved
-										</span>
-									{:else}
-										<span class="badge badge-error">
-											<svg
-												class="mr-1 h-3 w-3"
-												fill="none"
-												viewBox="0 0 24 24"
-												stroke="currentColor"
-											>
-												<path
-													stroke-linecap="round"
-													stroke-linejoin="round"
-													stroke-width="2"
-													d="M6 18L18 6M6 6l12 12"
-												/>
-											</svg>
-											Not Approved
-										</span>
-									{/if}
-								</td>
-							</tr>
-						{/each}
-					</tbody>
-				</table>
 			</div>
 		{/if}
 	{/if}


### PR DESCRIPTION
## Summary

- Add CSV parser with SS58 address validation and duplicate detection
- Create drag-drop file upload component with validation preview table
- Implement batch proposal creation service with progress tracking
- Add new `/proposals` page with 30-second auto-refresh polling
- Build call encoder using Blake2-256 hashing for CLAD Server integration

## Implementation Details

**New Components:**
- `CsvUpload.svelte` - Drag-drop file upload with size/type validation
- `CsvPreviewTable.svelte` - Preview parsed addresses with status filtering
- `BatchProgress.svelte` - Progress bar and result summary display

**New Services:**
- `csv-parser.ts` - Parse CSV, validate SS58 addresses, detect duplicates
- `call-encoder.ts` - Encode `addToWhitelist` calls with Blake2-256 hashing
- `batch-proposals.ts` - Submit batch proposals to CLAD Server with progress

**Modified:**
- Whitelist page now has tabs: "Status Lookup" and "Batch Upload"
- Sidebar includes new "Proposals" navigation item
- API client exports `listCallData()` for fetching proposals

## Test plan

- [ ] Upload valid CSV with SS58 addresses - should parse and show preview
- [ ] Upload CSV with invalid addresses - should mark as invalid in preview
- [ ] Upload CSV with duplicates - should detect and flag duplicates
- [ ] Create proposals from valid addresses - should show progress bar
- [ ] Navigate to /proposals - should list all proposals with auto-refresh
- [ ] Filter proposals by call type - should filter correctly

Closes #25